### PR TITLE
Add SMC2025

### DIFF
--- a/_conferences/2025-smc2025.md
+++ b/_conferences/2025-smc2025.md
@@ -1,0 +1,9 @@
+---
+title: 22nd Sound and Music Computing Conference
+acronym: SMC 2025
+date: '2025-07-10' # Conference date. Ensure mm and dd are 2 digits
+end_date: '2025-07-12' # Conference end date, leave empty if unknown
+submission_date: '2025-02-07' # Date of submissions
+ext_url: https://smc25.iem.at/ # External URL to conference website
+location: Graz, Austria # City, Country
+---


### PR DESCRIPTION
We are proudly hosting the "22nd Sound and Music Conference" in Graz/Austria next year!

**NOTE** for organizational reasons, we have different submission dates for the artistic and scientific . As I haven't found any example on how to deal with this, I've used the *earlier* of the two dates (that's the artistic call), as it makes it less likely to miss either. I hope this is correct way to do things :-)